### PR TITLE
add: github annotations for errors

### DIFF
--- a/lib/rspec/ci/prettify/annotation.rb
+++ b/lib/rspec/ci/prettify/annotation.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+module RSpec
+  module Ci
+    module Prettify
+        class Annotation
+            def initialize(notification)
+                @notification = notification
+                @example = notification.example
+            end
+
+            attr_reader :example, :notification
+
+            def line
+                location.split(':')[1]
+            end
+
+            def error
+                msg = notification.message_lines.join("\n")
+                format_annotation_err(msg)
+            end
+
+            def file
+                File.realpath(location.split(':')[0]).sub(/\A#{github_workspace_file_path}#{File::SEPARATOR}/, '')
+            end
+
+            private
+
+            def format_annotation_err(str)
+                stripped_str = strip_ansi_colours(str)
+                formatted_str = stripped_str.gsub("\n", '').gsub('"', "'")
+                formatted_str.squeeze(" ")
+            end
+
+            # running --force-color for rspec for a more readable CI
+            # output works great but unfortunately ANSI colours dont
+            # get parsed properly on github annotations therefore
+            # make them harder to read. Stripping any ANSI colours 
+            # on annotations here gives us the best of both worlds
+            # readable annotations and readable coloured CI
+            def strip_ansi_colours(str)
+                str.gsub(/\e\[(\d+)(;\d+)*m/, '')
+            end
+
+            def github_workspace_file_path
+                File.realpath(ENV.fetch('GITHUB_WORKSPACE', '.'))
+            end
+
+            def location
+                example.location
+            end
+        end
+    end
+  end
+end

--- a/lib/rspec/ci/prettify/formatter.rb
+++ b/lib/rspec/ci/prettify/formatter.rb
@@ -4,6 +4,7 @@ require 'rspec/core'
 require 'rspec/core/formatters/base_formatter'
 require 'rspec/core/formatters/console_codes'
 require_relative 'constants'
+require_relative 'annotation'
 
 module RSpec
   module Ci
@@ -20,7 +21,7 @@ module RSpec
           @output << "\n\n"
           @output << RSpec::Core::Formatters::ConsoleCodes.wrap(RSpec::Ci::Prettify::Constants::SEPARATOR, :bold_white)
           @output << "\n\n"
-          @output << RSpec::Core::Formatters::ConsoleCodes.wrap("SUMMARY:", :cyan)
+          @output << RSpec::Core::Formatters::ConsoleCodes.wrap('SUMMARY:', :cyan)
 
           build_summary(summary)
         end
@@ -29,7 +30,7 @@ module RSpec
           @output << "\n\n"
           @output << RSpec::Core::Formatters::ConsoleCodes.wrap(RSpec::Ci::Prettify::Constants::SEPARATOR, :bold_white)
           @output << "\n\n"
-          @output << RSpec::Core::Formatters::ConsoleCodes.wrap("PENDING:", :pending)
+          @output << RSpec::Core::Formatters::ConsoleCodes.wrap('PENDING:', :pending)
           @output << "\n\n\t"
 
           @output << notification.pending_examples.map do |example|
@@ -41,20 +42,19 @@ module RSpec
           @output << "\n\n"
           @output << RSpec::Core::Formatters::ConsoleCodes.wrap(RSpec::Ci::Prettify::Constants::SEPARATOR, :bold_white)
           @output << "\n\n"
-          @output << RSpec::Core::Formatters::ConsoleCodes.wrap("FAILURES:", :failure)
+          @output << RSpec::Core::Formatters::ConsoleCodes.wrap('FAILURES:', :failure)
           @output << "\n\n\t"
           @output << failed_examples_output(notification)
         end
 
-        def example_passed(example)
-
+        def example_failed(notification)
+          annotation = RSpec::Ci::Prettify::Annotation.new(notification)
+          output << "\n::error file=#{annotation.file},line=#{annotation.line}::#{annotation.error}"
         end
 
-        def example_failed(example)
-        end
+        def example_passed(_example); end
 
-        def example_pending(example)
-        end
+        def example_pending(_example); end
 
         def close(_notification)
           @output << "\n"
@@ -76,7 +76,8 @@ module RSpec
 
           if pass_count == total_tests_ran
             @output << "\n"
-            @output << RSpec::Core::Formatters::ConsoleCodes.wrap("All #{total_tests_ran} tests ran passed!!!", :magenta)
+            @output << RSpec::Core::Formatters::ConsoleCodes.wrap("All #{total_tests_ran} tests ran passed!!!",
+                                                                  :magenta)
             return
           end
           @output << "\n"


### PR DESCRIPTION
What
Add github annotations for rspec errors

Why
Some people enjoy the workflow of seeing failing tests in actions summary so preserving this behaviour as well as making actions output more readable is desireable.

We dont create annotations for pending examples as various warnings on large codebases make PRs very noisy and hard to review